### PR TITLE
Update playercore URLs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -44,9 +44,8 @@ chrome.webRequest.onBeforeRequest.addListener(
 		}
 	}, {
 		urls: [
-			"*://assets.nflxext.com/*/ffe/player/html/*",
-			"*://www.assets.nflxext.com/*/ffe/player/html/*",
-			"*://*.a.nflxso.net/sec/*/ffe/player/html/*"
+			"*://assets.nflxext.com/player/html/ffe/*",
+			"*://*.a.nflxso.net/sec/player/html/ffe/*"
 		]
 	}, ["blocking"]
 );

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,9 +16,8 @@
 		"storage",
 		"webRequest",
 		"webRequestBlocking",
-		"*://assets.nflxext.com/*/ffe/player/html/*",
-		"*://www.assets.nflxext.com/*/ffe/player/html/*",
-		"*://*.a.nflxso.net/sec/*/ffe/player/html/*",
+		"*://assets.nflxext.com/player/html/ffe/*",
+		"*://*.a.nflxso.net/sec/player/html/ffe/*",
 		"*://netflix.com/*",
 		"*://www.netflix.com/*"
 	]


### PR DESCRIPTION
The playercore assets have been moved to the following new URLs:

https://assets.nflxext.com/player/html/ffe/cadmium-playercore-6.0045.605.911.js
https://occ-weba-h2.a.nflxso.net/sec/player/html/ffe/cadmium-playercore-6.0045.605.911.js

Since www.assets.nflxext.com no longer exists, remove this entry
while we are at it.
